### PR TITLE
feat: free-tier fan-out, token KV cache, and batched sheet reads

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -64,6 +64,28 @@ describe('Cloudflare Worker Entrypoint', () => {
         typeof url === 'string' &&
         url.includes('sheets.googleapis.com/v4/spreadsheets/sheetid')
       ) {
+        // バッチ取得（values:batchGet）はメタデータ分岐（/values/を含まない）より前に判定
+        if (url.includes('values:batchGet')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                valueRanges: [
+                  {
+                    range: 'Sheet1!A2:D',
+                    values: [
+                      [
+                        'Server1',
+                        'https://a.com',
+                        'OK: Status 200',
+                        '2024-01-01 00:00:00',
+                      ],
+                    ],
+                  },
+                ],
+              }),
+          } as Response);
+        }
         // メタデータ取得
         if (!url.includes('/values/')) {
           return Promise.resolve({
@@ -197,6 +219,28 @@ describe('Cloudflare Worker Entrypoint', () => {
         typeof url === 'string' &&
         url.includes('sheets.googleapis.com/v4/spreadsheets/sheetid')
       ) {
+        // バッチ取得（values:batchGet）はメタデータ分岐（/values/を含まない）より前に判定
+        if (url.includes('values:batchGet')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                valueRanges: [
+                  {
+                    range: 'Sheet1!A2:D',
+                    values: [
+                      [
+                        'Server1',
+                        'https://a.com',
+                        'OK: Status 200',
+                        '2024-01-01 00:00:00',
+                      ],
+                    ],
+                  },
+                ],
+              }),
+          } as Response);
+        }
         if (!url.includes('/values/')) {
           return Promise.resolve({
             ok: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { Env, ServerStatus } from './types';
 import { getGoogleAccessToken } from './utils/google_jwt';
 import {
   fetchAllSheets,
-  fetchSheetRows,
+  fetchSheetsRows,
   sendDiscordWebhook,
 } from './utils/sheets_fetch';
 import { generateCurrentStatuses } from './utils/status';
@@ -17,254 +17,301 @@ function buildSheetUrlWithRange(
   return `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit#gid=${sheetId}&range=${sheetRow}:${sheetRow}`;
 }
 
+// 変化を検出した行（Discord通知・シート更新の対象）
+type ChangedRow = {
+  row: string[];
+  rowIndex: number;
+  statusObj: ServerStatus;
+};
+
+// 1シート分の監視処理。あらかじめ取得した行（rows）を受け取り、
+// 変化があった行のみDiscord通知＋シート更新を行う。KVは毎回保存する。
+async function processSheet(
+  env: Env,
+  fixedPrivateKey: string,
+  sheet: { sheetId: number; title: string },
+  rows: string[][],
+  offset: number,
+  limit: number
+): Promise<ChangedRow[]> {
+  const {
+    GOOGLE_CLIENT_EMAIL,
+    SPREADSHEET_ID,
+    DISCORD_WEBHOOK_URL,
+    DISCORD_MENTION_ROLE_ID,
+    STATUS_KV,
+  } = env;
+
+  const kvKey = `${SPREADSHEET_ID}-${sheet.sheetId}`;
+
+  // 1. KVから前回の状態を取得
+  const prevStatusesRaw = await STATUS_KV.get(kvKey);
+  const prevStatuses: Record<string, ServerStatus> = prevStatusesRaw
+    ? JSON.parse(prevStatusesRaw)
+    : {};
+
+  // 2. 監視対象を抽出（URL列が空でない行のみ）
+  const targets: { rowIndex: number; row: string[] }[] = [];
+  rows.forEach((row, rowIndex) => {
+    if (row[1]) {
+      targets.push({ rowIndex, row });
+    }
+  });
+
+  const chunk = targets.slice(offset, offset + limit);
+
+  // 3. chunk内の監視fetch
+  const changedRows: ChangedRow[] = [];
+  const newStatuses: Record<string, ServerStatus> = { ...prevStatuses };
+  await Promise.all(
+    chunk.map(async ({ row, rowIndex }) => {
+      const { currentStatuses } = await generateCurrentStatuses([row]);
+      const key = row[0] || row[1];
+      const statusObj = currentStatuses[key];
+      if (!statusObj) return;
+      const prev = prevStatuses[key];
+      // 前回とstatusが違う場合のみ通知・更新
+      if (!prev || prev.status !== statusObj.status) {
+        changedRows.push({ row, rowIndex, statusObj });
+      }
+      // 最新状態を保存
+      newStatuses[key] = statusObj;
+    })
+  );
+
+  // 4. Discord通知は変化があった行のみ
+  await Promise.all(
+    changedRows.map(async ({ row, rowIndex, statusObj }) => {
+      const isError = statusObj.status.startsWith('ERROR');
+      const sheetUrl = buildSheetUrlWithRange(
+        SPREADSHEET_ID,
+        sheet.sheetId,
+        rowIndex
+      );
+      const embed = {
+        title: isError
+          ? `:rotating_light: Server health check failure - ${sheet.title || 'Unknown Sheet'}`
+          : `:white_check_mark: Server Recovered - ${sheet.title || 'Unknown Sheet'}`,
+        color: isError ? 0xff0000 : 0x00ff00,
+        description: '',
+        fields: [
+          {
+            name: 'Server Name',
+            value: row[0] || 'N/A',
+            inline: true,
+          },
+          {
+            name: 'Server URL',
+            value: row[1] ? `${row[1]}` : 'N/A',
+            inline: true,
+          },
+          {
+            name: '\u200B',
+            value: '\u200B',
+            inline: true,
+          },
+          {
+            name: 'Status',
+            value: `${isError ? '🔴' : '🟢'} ${statusObj.status}`,
+            inline: true,
+          },
+          {
+            name: 'Last Updated',
+            value: statusObj.lastUpdate,
+            inline: true,
+          },
+          {
+            name: '\u200B',
+            value: '\u200B',
+            inline: true,
+          },
+          {
+            name: '\u200B',
+            value: `[📊 View in Google Sheets](${sheetUrl})`,
+            inline: false,
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      };
+      const content =
+        isError && DISCORD_MENTION_ROLE_ID
+          ? `<@&${DISCORD_MENTION_ROLE_ID}>`
+          : '';
+      await sendDiscordWebhook(DISCORD_WEBHOOK_URL, content, embed);
+    })
+  );
+
+  // 5. 値・書式のbatchUpdateは変化があった行があるときだけ実行する。
+  //    書き込みスコープのトークンも、その時だけ取得してsubrequestを節約する。
+  if (changedRows.length > 0) {
+    const updatesBySheet: { range: string; values: [string, string] }[] = [];
+    changedRows.forEach(({ rowIndex, statusObj }) => {
+      updatesBySheet.push({
+        range: `${sheet.title}!C${rowIndex + 2}:D${rowIndex + 2}`,
+        values: [statusObj.status, statusObj.lastUpdate],
+      });
+    });
+    const scope = 'https://www.googleapis.com/auth/spreadsheets';
+    const accessToken = await getGoogleAccessToken(
+      GOOGLE_CLIENT_EMAIL,
+      fixedPrivateKey,
+      scope,
+      STATUS_KV
+    );
+    const valuesUrl = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}/values:batchUpdate`;
+    const body = {
+      valueInputOption: 'USER_ENTERED',
+      data: updatesBySheet.map((u) => ({
+        range: u.range,
+        values: [u.values],
+      })),
+    };
+    await fetch(valuesUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    // 変化があった行のうち、エラー/OKで色分け
+    const formatRequests: {
+      repeatCell: {
+        range: {
+          sheetId: number;
+          startRowIndex: number;
+          endRowIndex: number;
+          startColumnIndex: number;
+          endColumnIndex: number;
+        };
+        cell: object;
+        fields: string;
+      };
+    }[] = [];
+    changedRows.forEach(({ rowIndex, statusObj }) => {
+      const isOk = statusObj.status.startsWith('OK');
+      formatRequests.push({
+        repeatCell: {
+          range: {
+            sheetId: sheet.sheetId,
+            startRowIndex: rowIndex + 1,
+            endRowIndex: rowIndex + 2,
+            startColumnIndex: 2, // C列
+            endColumnIndex: 3,
+          },
+          cell: isOk
+            ? { userEnteredFormat: {} }
+            : {
+                userEnteredFormat: {
+                  backgroundColor: { red: 1, green: 0.8, blue: 0.8 },
+                },
+              },
+          fields: 'userEnteredFormat',
+        },
+      });
+    });
+    // batchUpdateで書式リクエストを送信
+    const formatUrl = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}:batchUpdate`;
+    const formatBody = { requests: formatRequests };
+    await fetch(formatUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(formatBody),
+    });
+  }
+
+  // 6. シートごとにKVへ最新状態を保存（変化が無くても保存）
+  await STATUS_KV.put(kvKey, JSON.stringify(newStatuses));
+  return changedRows;
+}
+
+// 監視処理の本体。sheetId指定時はそのシートだけを対象にする（ファンアウトの子invocation用）。
+// 対象シートの行はまとめて1回のbatchGetで取得し、シートごとにprocessSheetを実行する。
+async function runHealthCheck(
+  env: Env,
+  opts: { sheetId?: number; offset: number; limit: number }
+): Promise<ChangedRow[]> {
+  const {
+    GOOGLE_CLIENT_EMAIL,
+    GOOGLE_PRIVATE_KEY,
+    SPREADSHEET_ID,
+    RANGE,
+    DISCORD_WEBHOOK_URL,
+    STATUS_KV,
+  } = env;
+
+  // 必須環境変数のチェック
+  if (
+    !GOOGLE_CLIENT_EMAIL ||
+    !GOOGLE_PRIVATE_KEY ||
+    !SPREADSHEET_ID ||
+    !DISCORD_WEBHOOK_URL
+  ) {
+    throw new Error('Missing required environment variables');
+  }
+
+  // 秘密鍵の改行を正しく処理
+  const fixedPrivateKey = GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n');
+
+  const allSheets = await fetchAllSheets(
+    GOOGLE_CLIENT_EMAIL,
+    fixedPrivateKey,
+    SPREADSHEET_ID,
+    STATUS_KV
+  );
+  // sheetId指定時はそのシートのみに絞り込む
+  const sheets =
+    opts.sheetId !== undefined
+      ? allSheets.filter((s) => s.sheetId === opts.sheetId)
+      : allSheets;
+
+  // 選択した全シートの行を1回のvalues:batchGetでまとめて取得
+  const ranges = sheets.map((s) => `${s.title}!${RANGE}`);
+  const rowsBySheet = await fetchSheetsRows(
+    GOOGLE_CLIENT_EMAIL,
+    fixedPrivateKey,
+    SPREADSHEET_ID,
+    ranges,
+    STATUS_KV
+  );
+
+  let allChangedRows: ChangedRow[] = [];
+  for (let i = 0; i < sheets.length; i++) {
+    const changedRows = await processSheet(
+      env,
+      fixedPrivateKey,
+      sheets[i],
+      rowsBySheet[i] || [],
+      opts.offset,
+      opts.limit
+    );
+    allChangedRows = allChangedRows.concat(changedRows);
+  }
+
+  return allChangedRows;
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     try {
-      const {
-        GOOGLE_CLIENT_EMAIL,
-        GOOGLE_PRIVATE_KEY,
-        SPREADSHEET_ID,
-        RANGE,
-        DISCORD_WEBHOOK_URL,
-        DISCORD_MENTION_ROLE_ID,
-        STATUS_KV,
-      } = env;
-
-      // 必須環境変数のチェック
-      if (
-        !GOOGLE_CLIENT_EMAIL ||
-        !GOOGLE_PRIVATE_KEY ||
-        !SPREADSHEET_ID ||
-        !DISCORD_WEBHOOK_URL
-      ) {
-        throw new Error('Missing required environment variables');
-      }
-
-      // 秘密鍵の改行を正しく処理
-      const fixedPrivateKey = GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n');
-
-      const sheets = await fetchAllSheets(
-        GOOGLE_CLIENT_EMAIL,
-        fixedPrivateKey,
-        SPREADSHEET_ID
-      );
-
-      // クエリパラメータでoffset/limitを指定可能に
+      // クエリパラメータでoffset/limit/sheetIdを指定可能に
       const url = new URL(request.url);
       const offset = parseInt(url.searchParams.get('offset') || '0', 10);
       const limit = parseInt(url.searchParams.get('limit') || '50', 10);
+      const sheetIdParam = url.searchParams.get('sheetId');
+      const sheetId =
+        sheetIdParam !== null ? parseInt(sheetIdParam, 10) : undefined;
 
-      let allChangedRows: {
-        row: string[];
-        rowIndex: number;
-        statusObj: ServerStatus;
-      }[] = [];
-
-      for (const sheet of sheets) {
-        const kvKey = `${SPREADSHEET_ID}-${sheet.sheetId}`;
-
-        // 1. シートごとに全行取得
-        const rows = await fetchSheetRows(
-          GOOGLE_CLIENT_EMAIL,
-          fixedPrivateKey,
-          SPREADSHEET_ID,
-          `${sheet.title}!${RANGE}`
-        );
-
-        // 2. KVから前回の状態を取得
-        const prevStatusesRaw = await STATUS_KV.get(kvKey);
-        const prevStatuses: Record<string, ServerStatus> = prevStatusesRaw
-          ? JSON.parse(prevStatusesRaw)
-          : {};
-
-        // 3. 監視対象を抽出
-        const targets: { rowIndex: number; row: string[] }[] = [];
-        rows.forEach((row, rowIndex) => {
-          if (row[1]) {
-            targets.push({ rowIndex, row });
-          }
-        });
-
-        const chunk = targets.slice(offset, offset + limit);
-
-        // 4. chunk内の監視fetch
-        const changedRows: {
-          row: string[];
-          rowIndex: number;
-          statusObj: ServerStatus;
-        }[] = [];
-        const newStatuses: Record<string, ServerStatus> = { ...prevStatuses };
-        await Promise.all(
-          chunk.map(async ({ row, rowIndex }) => {
-            const { currentStatuses } = await generateCurrentStatuses([row]);
-            const key = row[0] || row[1];
-            const statusObj = currentStatuses[key];
-            if (!statusObj) return;
-            const prev = prevStatuses[key];
-            // 前回とstatusが違う場合のみ通知・更新
-            if (!prev || prev.status !== statusObj.status) {
-              changedRows.push({ row, rowIndex, statusObj });
-            }
-            // 最新状態を保存
-            newStatuses[key] = statusObj;
-          })
-        );
-
-        // Discord通知・batchUpdateは変化があった行のみ
-        await Promise.all(
-          changedRows.map(async ({ row, rowIndex, statusObj }) => {
-            const isError = statusObj.status.startsWith('ERROR');
-            const sheetUrl = buildSheetUrlWithRange(
-              SPREADSHEET_ID,
-              sheet.sheetId,
-              rowIndex
-            );
-            const embed = {
-              title: isError
-                ? `:rotating_light: Server health check failure - ${sheet.title || 'Unknown Sheet'}`
-                : `:white_check_mark: Server Recovered - ${sheet.title || 'Unknown Sheet'}`,
-              color: isError ? 0xff0000 : 0x00ff00,
-              description: '',
-              fields: [
-                {
-                  name: 'Server Name',
-                  value: row[0] || 'N/A',
-                  inline: true,
-                },
-                {
-                  name: 'Server URL',
-                  value: row[1] ? `${row[1]}` : 'N/A',
-                  inline: true,
-                },
-                {
-                  name: '\u200B',
-                  value: '\u200B',
-                  inline: true,
-                },
-                {
-                  name: 'Status',
-                  value: `${isError ? '🔴' : '🟢'} ${statusObj.status}`,
-                  inline: true,
-                },
-                {
-                  name: 'Last Updated',
-                  value: statusObj.lastUpdate,
-                  inline: true,
-                },
-                {
-                  name: '\u200B',
-                  value: '\u200B',
-                  inline: true,
-                },
-                {
-                  name: '\u200B',
-                  value: `[📊 View in Google Sheets](${sheetUrl})`,
-                  inline: false,
-                },
-              ],
-              timestamp: new Date().toISOString(),
-            };
-            const content =
-              isError && DISCORD_MENTION_ROLE_ID
-                ? `<@&${DISCORD_MENTION_ROLE_ID}>`
-                : '';
-            await sendDiscordWebhook(DISCORD_WEBHOOK_URL, content, embed);
-          })
-        );
-
-        // batchUpdateも変化があった行のみ
-        const updatesBySheet: { range: string; values: [string, string] }[] =
-          [];
-        changedRows.forEach(({ rowIndex, statusObj }) => {
-          updatesBySheet.push({
-            range: `${sheet.title}!C${rowIndex + 2}:D${rowIndex + 2}`,
-            values: [statusObj.status, statusObj.lastUpdate],
-          });
-        });
-        const scope = 'https://www.googleapis.com/auth/spreadsheets';
-        const accessToken = await getGoogleAccessToken(
-          GOOGLE_CLIENT_EMAIL,
-          fixedPrivateKey,
-          scope
-        );
-        if (updatesBySheet.length > 0) {
-          const url = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}/values:batchUpdate`;
-          const body = {
-            valueInputOption: 'USER_ENTERED',
-            data: updatesBySheet.map((u) => ({
-              range: u.range,
-              values: [u.values],
-            })),
-          };
-          await fetch(url, {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(body),
-          });
-        }
-
-        // 変化があった行のうち、エラー/OKで色分け
-        const formatRequests: {
-          repeatCell: {
-            range: {
-              sheetId: number;
-              startRowIndex: number;
-              endRowIndex: number;
-              startColumnIndex: number;
-              endColumnIndex: number;
-            };
-            cell: object;
-            fields: string;
-          };
-        }[] = [];
-        changedRows.forEach(({ rowIndex, statusObj }) => {
-          const isOk = statusObj.status.startsWith('OK');
-          formatRequests.push({
-            repeatCell: {
-              range: {
-                sheetId: sheet.sheetId,
-                startRowIndex: rowIndex + 1,
-                endRowIndex: rowIndex + 2,
-                startColumnIndex: 2, // C列
-                endColumnIndex: 3,
-              },
-              cell: isOk
-                ? { userEnteredFormat: {} }
-                : {
-                    userEnteredFormat: {
-                      backgroundColor: { red: 1, green: 0.8, blue: 0.8 },
-                    },
-                  },
-              fields: 'userEnteredFormat',
-            },
-          });
-        });
-        // batchUpdateで書式リクエストを送信
-        if (formatRequests.length > 0) {
-          const formatUrl = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}:batchUpdate`;
-          const formatBody = { requests: formatRequests };
-          await fetch(formatUrl, {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(formatBody),
-          });
-        }
-
-        // シートごとにKVへ最新状態を保存
-        await STATUS_KV.put(kvKey, JSON.stringify(newStatuses));
-        allChangedRows = allChangedRows.concat(changedRows);
-      }
+      const results = await runHealthCheck(env, { sheetId, offset, limit });
 
       return new Response(
         JSON.stringify({
           message: 'Server health check complete',
-          results: allChangedRows,
+          results,
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } }
       );
@@ -277,9 +324,47 @@ export default {
     }
   },
   async scheduled(event: ScheduledEvent, env: Env, _ctx: ExecutionContext) {
-    // 定期実行時もfetchと同じ監視処理を実行
-    // fetchと同じエンドポイントロジックを呼び出す
-    const req = new Request('https://dummy-cron-trigger');
-    await this.fetch(req, env);
+    try {
+      const hasRequiredEnv =
+        env.GOOGLE_CLIENT_EMAIL &&
+        env.GOOGLE_PRIVATE_KEY &&
+        env.SPREADSHEET_ID &&
+        env.DISCORD_WEBHOOK_URL;
+
+      // SELFバインディングがあれば、シートごとに自分自身を子invocationとして呼び出す。
+      // 各子invocationは新たな50 subrequest枠を得るため、合計の監視可能数を増やせる。
+      // ファンアウトはシート単位（任意チャンク単位ではない）にして、KVキーごとの
+      // 書き込み者が1実行につき必ず1つになるようにする。
+      if (env.SELF && hasRequiredEnv) {
+        const self = env.SELF;
+        const fixedPrivateKey = env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n');
+        const sheets = await fetchAllSheets(
+          env.GOOGLE_CLIENT_EMAIL,
+          fixedPrivateKey,
+          env.SPREADSHEET_ID,
+          env.STATUS_KV
+        );
+        const fanoutLimit = parseInt(env.FANOUT_LIMIT || '45', 10);
+        for (const sheet of sheets) {
+          // 1つの子が失敗しても残りを止めないよう、各呼び出しをcatchする
+          await self
+            .fetch(
+              `https://smartwatchdog.internal/?sheetId=${sheet.sheetId}&limit=${fanoutLimit}`
+            )
+            .catch((err) => {
+              console.error(`Fan-out failed for sheet ${sheet.sheetId}:`, err);
+            });
+        }
+        return;
+      }
+
+      // フォールバック: SELF未設定（dev/local/テスト）では従来どおり逐次処理
+      await runHealthCheck(env, {
+        offset: 0,
+        limit: parseInt(env.FANOUT_LIMIT || '45', 10),
+      });
+    } catch (e) {
+      console.error('Scheduled handler error:', e);
+    }
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,4 +18,8 @@ export interface Env {
   STATUS_KV: KVNamespace;
   DISCORD_MENTION_ROLE_ID?: string;
   RANGE: string;
+  // 自己宛サービスバインディング。scheduledでシートごとに子invocationへファンアウトする
+  SELF?: Fetcher;
+  // 子invocation1回あたりの監視上限（既定45。subrequest上限50に対する余裕分）
+  FANOUT_LIMIT?: string;
 }

--- a/src/utils/google_jwt.ts
+++ b/src/utils/google_jwt.ts
@@ -66,11 +66,27 @@ async function createJWT(
 }
 
 // JWTでアクセストークン取得
+// kvを渡すと取得済みトークンをKVにキャッシュし、サブリクエスト数を削減する。
+// KVの読み書きで失敗しても、その都度新規発行にフォールバックするだけで致命的にはしない。
 export async function getGoogleAccessToken(
   clientEmail: string,
   privateKey: string,
-  scope: string
+  scope: string,
+  kv?: KVNamespace
 ): Promise<string> {
+  const cacheKey = `gtoken:${clientEmail}:${scope}`;
+
+  // 1. キャッシュ確認（kv指定時のみ）
+  if (kv) {
+    try {
+      const cached = await kv.get(cacheKey);
+      if (cached) return cached;
+    } catch {
+      // KV読み取り失敗時は新規発行にフォールバック
+    }
+  }
+
+  // 2. キャッシュミス時は従来どおり発行
   const jwt = await createJWT(clientEmail, privateKey, scope);
   const params = new URLSearchParams({
     grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
@@ -83,9 +99,21 @@ export async function getGoogleAccessToken(
   });
   const data = (await resp.json()) as {
     access_token?: string;
+    expires_in?: number;
     [key: string]: unknown;
   };
   if (!data.access_token)
     throw new Error('Failed to get access token: ' + JSON.stringify(data));
+
+  // 3. 取得したトークンをKVへ保存（有効期限の5分前で失効させる）
+  if (kv) {
+    try {
+      const expirationTtl = Math.max(60, (data.expires_in ?? 3600) - 300);
+      await kv.put(cacheKey, data.access_token, { expirationTtl });
+    } catch {
+      // KV書き込み失敗は無視（トークン自体は取得済み）
+    }
+  }
+
   return data.access_token;
 }

--- a/src/utils/sheets_fetch.test.ts
+++ b/src/utils/sheets_fetch.test.ts
@@ -71,7 +71,8 @@ describe('sheets_fetch', () => {
       expect(mockGetGoogleAccessToken).toHaveBeenCalledWith(
         'test@example.com',
         'private-key',
-        'https://www.googleapis.com/auth/spreadsheets.readonly'
+        'https://www.googleapis.com/auth/spreadsheets.readonly',
+        undefined
       );
     });
 

--- a/src/utils/sheets_fetch.ts
+++ b/src/utils/sheets_fetch.ts
@@ -5,13 +5,15 @@ import { generateCurrentStatuses } from './status';
 export async function fetchAllSheets(
   clientEmail: string,
   privateKey: string,
-  spreadsheetId: string
+  spreadsheetId: string,
+  kv?: KVNamespace
 ): Promise<{ sheetId: number; title: string }[]> {
   const scope = 'https://www.googleapis.com/auth/spreadsheets.readonly';
   const accessToken = await getGoogleAccessToken(
     clientEmail,
     privateKey,
-    scope
+    scope,
+    kv
   );
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}`;
   const resp = await fetch(url, {
@@ -69,13 +71,15 @@ export async function fetchSheetRows(
   clientEmail: string,
   privateKey: string,
   spreadsheetId: string,
-  range: string
+  range: string,
+  kv?: KVNamespace
 ): Promise<string[][]> {
   const scope = 'https://www.googleapis.com/auth/spreadsheets.readonly';
   const accessToken = await getGoogleAccessToken(
     clientEmail,
     privateKey,
-    scope
+    scope,
+    kv
   );
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(range)}`;
   const resp = await fetch(url, {
@@ -87,6 +91,38 @@ export async function fetchSheetRows(
   }
   const data = (await resp.json()) as { values: string[][] };
   return data.values || [];
+}
+
+// 複数レンジの行を1回のvalues:batchGetでまとめて取得（サブリクエスト削減）
+// 戻り値はrangesと同じ順序の二次元配列の配列。値が無いレンジは空配列。
+export async function fetchSheetsRows(
+  clientEmail: string,
+  privateKey: string,
+  spreadsheetId: string,
+  ranges: string[],
+  kv?: KVNamespace
+): Promise<string[][][]> {
+  if (ranges.length === 0) return [];
+  const scope = 'https://www.googleapis.com/auth/spreadsheets.readonly';
+  const accessToken = await getGoogleAccessToken(
+    clientEmail,
+    privateKey,
+    scope,
+    kv
+  );
+  const query = ranges.map((r) => `ranges=${encodeURIComponent(r)}`).join('&');
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values:batchGet?${query}`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error('Failed to fetch sheet rows (batch): ' + text);
+  }
+  const data = (await resp.json()) as {
+    valueRanges?: { values?: string[][] }[];
+  };
+  return ranges.map((_, i) => data.valueRanges?.[i]?.values || []);
 }
 
 // ステータスをチェックし、変化があった行だけbatchUpdateで書き込む＋背景色も更新

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,15 +8,24 @@ GOOGLE_CLIENT_EMAIL = "notify@cf-sheetswatchdog.iam.gserviceaccount.com"
 SPREADSHEET_ID = "1GjPdvHMEWJMAk7wLUWPWdJuJmfxvc8Av_1sq1Q3NQ-8"
 RANGE = "A2:D"
 DISCORD_MENTION_ROLE_ID = "1227585802712911892"
+FANOUT_LIMIT = "45"
 
 # Cron Trigger to run every 5 minutes
 [triggers]
-crons = ["*/10 * * * *"] 
+crons = ["*/10 * * * *"]
 
 # KV Namespace binding (applies to all environments)
 [[kv_namespaces]]
 binding = "STATUS_KV"
 id = "bb7a0427a0724e9ea48aaec2714ddad9"
+
+# Self service binding: scheduledがシートごとに自分自身を子として呼び出すために使用。
+# 各子invocationは新たな50 subrequest枠を得るため、合計の監視可能数を増やせる。
+# 注意: 初回デプロイ時はこのserviceがまだ存在せず失敗する場合がある。
+# その1回だけこの[[services]]ブロックをコメントアウトしてデプロイ→復帰して再デプロイする。
+[[services]]
+binding = "SELF"
+service = "smartwatchdog"
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
## Goal
Raise the number of monitored endpoints past the ~30 wall while staying on the Cloudflare Workers free tier (50 subrequests/invocation).

## Changes
1. **Token KV cache** (`google_jwt.ts`) — cache the Google OAuth token in KV (TTL = lifetime - 5 min); removes repeated token subrequests within and across invocations. KV failures fall back to minting a fresh token.
2. **Batched sheet reads** (`sheets_fetch.ts`) — new `fetchSheetsRows()` reads every sheet range in a single `values:batchGet` call instead of one request per sheet.
3. **Per-sheet fan-out** (`index.ts`, `wrangler.toml`, `types.ts`) — a self service binding (`SELF`) lets `scheduled` dispatch one child invocation per sheet, each with a fresh 50-subrequest budget. Adds a `?sheetId=` single-sheet mode and falls back to inline sequential processing when `SELF` is unset. The write-scope token is only fetched when there are changes.

## Budget per child (one sheet)
metadata 1 + batchGet 1 + writes 2 (on change) ≈ 3-5 fixed; ~45 left for health checks ⇒ ~45/sheet; total ≈ FANOUT_LIMIT × sheets.

## Notes / review
- Per-sheet (not per-chunk) fan-out keeps exactly one writer per KV key. If a single sheet exceeds FANOUT_LIMIT (45) targets, the overflow is skipped this run — split that tab, or move to per-target KV keys later.
- `SELF` is a self-referential service binding; the **first** deploy can fail because the service doesn't exist yet. For that one deploy, comment out the `[[services]]` block, deploy, then uncomment and redeploy.
- CI (build / test / lint / prettier) passes locally.
