### PR TITLE
fix: keep per-sheet fan-out under the 50-subrequest cap + stop stalled-response cancellations

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -185,6 +185,27 @@ describe('Cloudflare Worker Entrypoint', () => {
     expect(body.error).toMatch(/Missing required environment variables/);
   });
 
+  it('fetch: sheetId+title 指定時はmetadata取得を省略する（子invocation最適化）', async () => {
+    const req = new Request('https://example.com?sheetId=1&title=Sheet1');
+    const res = await handler.fetch(req, env);
+    expect(res.status).toBe(200);
+
+    const calls = (global.fetch as jest.Mock).mock.calls.map((c) =>
+      String(c[0])
+    );
+    // 行取得は values:batchGet で行われる
+    expect(calls.some((u) => u.includes('values:batchGet'))).toBe(true);
+    // metadata（/v4/spreadsheets/sheetid で values/batchGet/batchUpdate を含まない）は呼ばれない
+    const metadataCalled = calls.some(
+      (u) =>
+        u.includes('/v4/spreadsheets/sheetid') &&
+        !u.includes('values:batchGet') &&
+        !u.includes(':batchUpdate') &&
+        !u.includes('/values/')
+    );
+    expect(metadataCalled).toBe(false);
+  });
+
   it('scheduled: cronトリガーのテスト', async () => {
     const event = {
       scheduledTime: Date.now(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,7 @@ async function processSheet(
 // 対象シートの行はまとめて1回のbatchGetで取得し、シートごとにprocessSheetを実行する。
 async function runHealthCheck(
   env: Env,
-  opts: { sheetId?: number; offset: number; limit: number }
+  opts: { sheetId?: number; title?: string; offset: number; limit: number }
 ): Promise<ChangedRow[]> {
   const {
     GOOGLE_CLIENT_EMAIL,
@@ -257,17 +257,23 @@ async function runHealthCheck(
   // 秘密鍵の改行を正しく処理
   const fixedPrivateKey = GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n');
 
-  const allSheets = await fetchAllSheets(
-    GOOGLE_CLIENT_EMAIL,
-    fixedPrivateKey,
-    SPREADSHEET_ID,
-    STATUS_KV
-  );
-  // sheetId指定時はそのシートのみに絞り込む
-  const sheets =
-    opts.sheetId !== undefined
-      ? allSheets.filter((s) => s.sheetId === opts.sheetId)
-      : allSheets;
+  // 対象シートの確定。子invocation（sheetId+title指定）では metadata 取得を省いて
+  // subrequestを1つ節約する。それ以外は従来どおり全シートを取得して必要なら絞り込む。
+  let sheets: { sheetId: number; title: string }[];
+  if (opts.sheetId !== undefined && opts.title) {
+    sheets = [{ sheetId: opts.sheetId, title: opts.title }];
+  } else {
+    const allSheets = await fetchAllSheets(
+      GOOGLE_CLIENT_EMAIL,
+      fixedPrivateKey,
+      SPREADSHEET_ID,
+      STATUS_KV
+    );
+    sheets =
+      opts.sheetId !== undefined
+        ? allSheets.filter((s) => s.sheetId === opts.sheetId)
+        : allSheets;
+  }
 
   // 選択した全シートの行を1回のvalues:batchGetでまとめて取得
   const ranges = sheets.map((s) => `${s.title}!${RANGE}`);
@@ -298,15 +304,22 @@ async function runHealthCheck(
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     try {
-      // クエリパラメータでoffset/limit/sheetIdを指定可能に
+      // クエリパラメータでoffset/limit/sheetId/titleを指定可能に
       const url = new URL(request.url);
       const offset = parseInt(url.searchParams.get('offset') || '0', 10);
       const limit = parseInt(url.searchParams.get('limit') || '50', 10);
       const sheetIdParam = url.searchParams.get('sheetId');
       const sheetId =
         sheetIdParam !== null ? parseInt(sheetIdParam, 10) : undefined;
+      // titleがあれば子invocationはmetadata取得を省ける
+      const title = url.searchParams.get('title') || undefined;
 
-      const results = await runHealthCheck(env, { sheetId, offset, limit });
+      const results = await runHealthCheck(env, {
+        sheetId,
+        title,
+        offset,
+        limit,
+      });
 
       return new Response(
         JSON.stringify({
@@ -349,7 +362,7 @@ export default {
           // 1つの子が失敗しても残りを止めないよう、各呼び出しをcatchする
           await self
             .fetch(
-              `https://smartwatchdog.internal/?sheetId=${sheet.sheetId}&limit=${fanoutLimit}`
+              `https://smartwatchdog.internal/?sheetId=${sheet.sheetId}&title=${encodeURIComponent(sheet.title)}&limit=${fanoutLimit}`
             )
             .catch((err) => {
               console.error(`Fan-out failed for sheet ${sheet.sheetId}:`, err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ async function processSheet(
         values: [u.values],
       })),
     };
-    await fetch(valuesUrl, {
+    const valuesResp = await fetch(valuesUrl, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -174,6 +174,8 @@ async function processSheet(
       },
       body: JSON.stringify(body),
     });
+    // bodyは使わないがcancelしないと接続が滞留し同時実行上限でstall→cancelされる
+    await valuesResp.body?.cancel();
 
     // 変化があった行のうち、エラー/OKで色分け
     const formatRequests: {
@@ -214,7 +216,7 @@ async function processSheet(
     // batchUpdateで書式リクエストを送信
     const formatUrl = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}:batchUpdate`;
     const formatBody = { requests: formatRequests };
-    await fetch(formatUrl, {
+    const formatResp = await fetch(formatUrl, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -222,6 +224,8 @@ async function processSheet(
       },
       body: JSON.stringify(formatBody),
     });
+    // 同上: 使わないbodyはcancelして接続を解放する
+    await formatResp.body?.cancel();
   }
 
   // 6. シートごとにKVへ最新状態を保存（変化が無くても保存）

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,7 +344,7 @@ export default {
           env.SPREADSHEET_ID,
           env.STATUS_KV
         );
-        const fanoutLimit = parseInt(env.FANOUT_LIMIT || '45', 10);
+        const fanoutLimit = parseInt(env.FANOUT_LIMIT || '40', 10);
         for (const sheet of sheets) {
           // 1つの子が失敗しても残りを止めないよう、各呼び出しをcatchする
           await self
@@ -361,7 +361,7 @@ export default {
       // フォールバック: SELF未設定（dev/local/テスト）では従来どおり逐次処理
       await runHealthCheck(env, {
         offset: 0,
-        limit: parseInt(env.FANOUT_LIMIT || '45', 10),
+        limit: parseInt(env.FANOUT_LIMIT || '40', 10),
       });
     } catch (e) {
       console.error('Scheduled handler error:', e);

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface Env {
   RANGE: string;
   // 自己宛サービスバインディング。scheduledでシートごとに子invocationへファンアウトする
   SELF?: Fetcher;
-  // 子invocation1回あたりの監視上限（既定45。subrequest上限50に対する余裕分）
+  // 子invocation1回あたりの監視上限（既定40。subrequest上限50に対しmetadata/batchGet/
+  // 書き込み/Discord通知のオーバーヘッド分の余裕を残す）
   FANOUT_LIMIT?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface Env {
   RANGE: string;
   // 自己宛サービスバインディング。scheduledでシートごとに子invocationへファンアウトする
   SELF?: Fetcher;
-  // 子invocation1回あたりの監視上限（既定40。subrequest上限50に対しmetadata/batchGet/
-  // 書き込み/Discord通知のオーバーヘッド分の余裕を残す）
+  // 子invocation1回あたりの監視上限（既定40。subrequest上限50に対し
+  // batchGet/書き込み/Discord通知のオーバーヘッド分の余裕を残す。子モードはmetadataを省略）
   FANOUT_LIMIT?: string;
 }

--- a/src/utils/sheets_fetch.ts
+++ b/src/utils/sheets_fetch.ts
@@ -301,9 +301,12 @@ export async function sendDiscordWebhook(
 ) {
   const body: Record<string, unknown> = { content };
   if (embed) body.embeds = [embed];
-  await fetch(webhookUrl, {
+  const resp = await fetch(webhookUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+  // レスポンスbodyを読まないと接続が開いたままになり、同時実行が上限に達して
+  // "stalled HTTP response was canceled" を誘発する。使わないのでcancelする。
+  await resp.body?.cancel();
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,10 +8,10 @@ GOOGLE_CLIENT_EMAIL = "notify@cf-sheetswatchdog.iam.gserviceaccount.com"
 SPREADSHEET_ID = "1GjPdvHMEWJMAk7wLUWPWdJuJmfxvc8Av_1sq1Q3NQ-8"
 RANGE = "A2:D"
 DISCORD_MENTION_ROLE_ID = "1227585802712911892"
-# 子invocation1回あたりの監視上限。1呼び出しの subrequest 上限は50で、
-# 内訳は metadata(1) + batchGet(1) + 変化時の write-scope oauth(1) + 値/書式の
-# batchUpdate(2) + Discord通知(変化数) を消費する。45 だと変化が1件でも超過するため、
-# それらのオーバーヘッド分の余裕を残して 40 に設定する（1タブが40行超なら分割推奨）。
+# 子invocation1回あたりの監視上限。1呼び出しの subrequest 上限は50。
+# 子モードは title をURLで受け取り metadata 取得を省くため、内訳は
+# batchGet(1) + 変化時 write-scope oauth(1) + 値/書式 batchUpdate(2) + Discord通知(変化数)。
+# 45 だと変化数次第で超過するため、余裕をもって 40 に設定（1タブが40行超なら分割推奨）。
 FANOUT_LIMIT = "40"
 
 # Cron Trigger to run every 5 minutes

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,11 @@ GOOGLE_CLIENT_EMAIL = "notify@cf-sheetswatchdog.iam.gserviceaccount.com"
 SPREADSHEET_ID = "1GjPdvHMEWJMAk7wLUWPWdJuJmfxvc8Av_1sq1Q3NQ-8"
 RANGE = "A2:D"
 DISCORD_MENTION_ROLE_ID = "1227585802712911892"
-FANOUT_LIMIT = "45"
+# 子invocation1回あたりの監視上限。1呼び出しの subrequest 上限は50で、
+# 内訳は metadata(1) + batchGet(1) + 変化時の write-scope oauth(1) + 値/書式の
+# batchUpdate(2) + Discord通知(変化数) を消費する。45 だと変化が1件でも超過するため、
+# それらのオーバーヘッド分の余裕を残して 40 に設定する（1タブが40行超なら分割推奨）。
+FANOUT_LIMIT = "40"
 
 # Cron Trigger to run every 5 minutes
 [triggers]


### PR DESCRIPTION
## Problem (observed in production)
After #19 deployed, live cron runs failed two ways:

```
GET https://smartwatchdog.internal/?sheetId=0&limit=45 - Canceled
  (error) Worker error: Too many subrequests by single Worker invocation
(warn) A stalled HTTP response was canceled to prevent deadlock ...
```

The fan-out **mechanism works** (the `SELF` binding dispatched per-sheet children with the right `?sheetId=&limit=`), but two budget problems surfaced.

## Changes
1. **Lower default `FANOUT_LIMIT` 45 → 40** (`wrangler.toml` + code fallback). With 45, metadata(1) + batchGet(1) + 45 health checks + write-oauth(1) + 2 batchUpdates + Discord exceeded the free-tier 50-subrequest cap as soon as a row changed.
2. **Skip the redundant metadata fetch in single-sheet (child) mode.** The fan-out URL now carries `&title=`; when `sheetId`+`title` are present, `runHealthCheck` builds the sheet directly instead of calling `fetchAllSheets`. Saves 1 subrequest/child and one Sheets metadata API call per child per cron. Manual `?sheetId=` without `title` still falls back (unchanged).
3. **Cancel unread fetch response bodies.** The Discord webhook and the value/format `batchUpdate` writes never read their response bodies, so connections stayed in-flight and tripped "A stalled HTTP response was canceled to prevent deadlock." Each now calls `response.body?.cancel()` (same pattern the health-check path uses).

## Resulting per-child budget
batchGet(1) + health checks(L≤40) + on change: write-oauth(1) + value/format batchUpdate(2) + Discord(D) → `~3 + L + D`, comfortably under 50.

## Notes
- A tab with more than ~40 monitored rows should be **split** so each fits one child's budget (overflow is skipped for that run).
- Immediate mitigation without redeploy: set the `FANOUT_LIMIT` plaintext var to `40` in the Worker dashboard (Settings → Variables).
- Build / test (37, incl. a metadata-skip regression test) / lint / prettier all pass locally.
