### PR TITLE
fix: consume fan-out child response bodies so children aren't canceled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -363,14 +363,17 @@ export default {
         );
         const fanoutLimit = parseInt(env.FANOUT_LIMIT || '40', 10);
         for (const sheet of sheets) {
-          // 1つの子が失敗しても残りを止めないよう、各呼び出しをcatchする
-          await self
-            .fetch(
+          // 1つの子が失敗しても残りを止めないよう、各呼び出しをtry/catchで囲む。
+          // 子レスポンスのbodyを読み切らないと、親invocation終了時に子が打ち切られて
+          // tail上 "Canceled" になる。結果は使わないが必ず読み切って完了を待つ。
+          try {
+            const childResp = await self.fetch(
               `https://smartwatchdog.internal/?sheetId=${sheet.sheetId}&title=${encodeURIComponent(sheet.title)}&limit=${fanoutLimit}`
-            )
-            .catch((err) => {
-              console.error(`Fan-out failed for sheet ${sheet.sheetId}:`, err);
-            });
+            );
+            await childResp.text();
+          } catch (err) {
+            console.error(`Fan-out failed for sheet ${sheet.sheetId}:`, err);
+          }
         }
         return;
       }


### PR DESCRIPTION
## Problem (from production tail)
After #20 deployed, the cron's per-sheet children appeared as `Canceled`:

```
?sheetId=0&title=mofumofu.me&limit=40 - Canceled
?sheetId=1622791164&title=Other&limit=40 - Canceled
?sheetId=353161749&title=virbicoin.com&limit=40 - Canceled
"*/10 * * * *" - Ok
```

The `Too many subrequests` error is gone (the FANOUT_LIMIT=40 + metadata-skip from #20 worked). The remaining `Canceled` is because the scheduled parent awaited each `env.SELF.fetch(...)` but never read the child's response body, so the runtime canceled the in-flight child responses when the parent finished.

## Fix
Read the child response body to completion (`await childResp.text()`) inside a try/catch. This removes the misleading `Canceled` label, makes the parent wait for full child completion, and avoids a stalled-response deadlock when many sheets are dispatched.

Build / test (37) / lint / prettier pass locally.
