### PR TITLE
feat: fan out the root endpoint per sheet so manual GET / stays under the cap

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -223,6 +223,32 @@ describe('Cloudflare Worker Entrypoint', () => {
     expect(mockPut).toHaveBeenCalled();
   });
 
+  it('fetch: sheetId未指定でSELFありの場合はシート単位にファンアウトする', async () => {
+    const selfFetch = jest.fn(
+      async (_input: string | URL) => new Response('{}', { status: 200 })
+    );
+    const envWithSelf: Env = {
+      ...env,
+      SELF: { fetch: selfFetch } as unknown as Fetcher,
+    };
+
+    const req = new Request('https://example.com');
+    const res = await handler.fetch(req, envWithSelf);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      message: string;
+      dispatched: number;
+    };
+    expect(body.message).toMatch(/fanned out/i);
+    // メタデータのシート(Sheet1)ごとに子をディスパッチ
+    expect(body.dispatched).toBe(1);
+    expect(selfFetch).toHaveBeenCalledTimes(1);
+    const calledUrl = String(selfFetch.mock.calls[0][0]);
+    expect(calledUrl).toContain('sheetId=1');
+    expect(calledUrl).toContain('title=Sheet1');
+    expect(calledUrl).toContain('limit=40');
+  });
+
   it('fetch: KVエラー時の処理', async () => {
     mockGet.mockRejectedValue(new Error('KV error'));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,14 +305,70 @@ async function runHealthCheck(
   return allChangedRows;
 }
 
+// 必須環境変数が揃っているか
+function hasRequiredEnv(env: Env): boolean {
+  return !!(
+    env.GOOGLE_CLIENT_EMAIL &&
+    env.GOOGLE_PRIVATE_KEY &&
+    env.SPREADSHEET_ID &&
+    env.DISCORD_WEBHOOK_URL
+  );
+}
+
+// SELFバインディング経由でシート単位に子invocationへファンアウトする。
+// 各子は新たな50 subrequest枠を持つため、合計の監視可能数を増やせる。
+// ファンアウトはシート単位（任意チャンク単位ではない）にして、KVキーごとの
+// 書き込み者が1実行につき必ず1つになるようにする。戻り値はディスパッチしたシート数。
+async function fanOutPerSheet(env: Env): Promise<number> {
+  const self = env.SELF;
+  if (!self) return 0;
+  const fixedPrivateKey = env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n');
+  const sheets = await fetchAllSheets(
+    env.GOOGLE_CLIENT_EMAIL,
+    fixedPrivateKey,
+    env.SPREADSHEET_ID,
+    env.STATUS_KV
+  );
+  const fanoutLimit = parseInt(env.FANOUT_LIMIT || '40', 10);
+  for (const sheet of sheets) {
+    // 1つの子が失敗しても残りを止めないようtry/catch。
+    // 子レスポンスのbodyを読み切らないと、親invocation終了時に子が打ち切られて
+    // tail上 "Canceled" になる。結果は使わないが必ず読み切って完了を待つ。
+    try {
+      const childResp = await self.fetch(
+        `https://smartwatchdog.internal/?sheetId=${sheet.sheetId}&title=${encodeURIComponent(sheet.title)}&limit=${fanoutLimit}`
+      );
+      await childResp.text();
+    } catch (err) {
+      console.error(`Fan-out failed for sheet ${sheet.sheetId}:`, err);
+    }
+  }
+  return sheets.length;
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     try {
       // クエリパラメータでoffset/limit/sheetId/titleを指定可能に
       const url = new URL(request.url);
+      const sheetIdParam = url.searchParams.get('sheetId');
+
+      // sheetId未指定でSELFがあれば、cronと同じくシート単位でファンアウトする。
+      // 引数なしの/を1 invocationで全シート処理すると50 subrequest上限を超えるため。
+      if (sheetIdParam === null && env.SELF && hasRequiredEnv(env)) {
+        const dispatched = await fanOutPerSheet(env);
+        return new Response(
+          JSON.stringify({
+            message: 'Server health check fanned out',
+            dispatched,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // それ以外（sheetId指定 or SELF未設定）は同一invocationで処理する
       const offset = parseInt(url.searchParams.get('offset') || '0', 10);
       const limit = parseInt(url.searchParams.get('limit') || '50', 10);
-      const sheetIdParam = url.searchParams.get('sheetId');
       const sheetId =
         sheetIdParam !== null ? parseInt(sheetIdParam, 10) : undefined;
       // titleがあれば子invocationはmetadata取得を省ける
@@ -342,39 +398,9 @@ export default {
   },
   async scheduled(event: ScheduledEvent, env: Env, _ctx: ExecutionContext) {
     try {
-      const hasRequiredEnv =
-        env.GOOGLE_CLIENT_EMAIL &&
-        env.GOOGLE_PRIVATE_KEY &&
-        env.SPREADSHEET_ID &&
-        env.DISCORD_WEBHOOK_URL;
-
-      // SELFバインディングがあれば、シートごとに自分自身を子invocationとして呼び出す。
-      // 各子invocationは新たな50 subrequest枠を得るため、合計の監視可能数を増やせる。
-      // ファンアウトはシート単位（任意チャンク単位ではない）にして、KVキーごとの
-      // 書き込み者が1実行につき必ず1つになるようにする。
-      if (env.SELF && hasRequiredEnv) {
-        const self = env.SELF;
-        const fixedPrivateKey = env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n');
-        const sheets = await fetchAllSheets(
-          env.GOOGLE_CLIENT_EMAIL,
-          fixedPrivateKey,
-          env.SPREADSHEET_ID,
-          env.STATUS_KV
-        );
-        const fanoutLimit = parseInt(env.FANOUT_LIMIT || '40', 10);
-        for (const sheet of sheets) {
-          // 1つの子が失敗しても残りを止めないよう、各呼び出しをtry/catchで囲む。
-          // 子レスポンスのbodyを読み切らないと、親invocation終了時に子が打ち切られて
-          // tail上 "Canceled" になる。結果は使わないが必ず読み切って完了を待つ。
-          try {
-            const childResp = await self.fetch(
-              `https://smartwatchdog.internal/?sheetId=${sheet.sheetId}&title=${encodeURIComponent(sheet.title)}&limit=${fanoutLimit}`
-            );
-            await childResp.text();
-          } catch (err) {
-            console.error(`Fan-out failed for sheet ${sheet.sheetId}:`, err);
-          }
-        }
+      // SELFがあればシート単位でファンアウト（各子が新たな50 subrequest枠を得る）
+      if (env.SELF && hasRequiredEnv(env)) {
+        await fanOutPerSheet(env);
         return;
       }
 


### PR DESCRIPTION
## Problem
`GET /` with no query params runs every sheet in a single invocation, exceeding the free-tier 50-subrequest cap once there are several tabs:

```
GET https://smartwatchdog.mofumofu.workers.dev/ - Ok
  (error) Worker error: Too many subrequests by single Worker invocation
```

(The cron path already fans out per sheet and works; this only affected the bare `/` manual endpoint.)

## Change
Make `fetch` mirror the cron: when no `sheetId` is given and the `SELF` binding + required env vars are present, dispatch one child invocation per sheet (each with its own 50-subrequest budget) and return `{ message, dispatched }`.

- Per-sheet fan-out is factored into a shared `fanOutPerSheet(env)` helper, now used by both `scheduled` and `fetch` (removes the duplicated loop). `hasRequiredEnv(env)` extracted too.
- When `SELF` is unset (dev/local/tests) or a specific `?sheetId=` is requested, behavior is unchanged (single-invocation path).
- Note: each `GET /` now triggers a full per-sheet monitoring run (health checks + Discord on change), same side effects as a cron tick — intended for manual triggering.

## Tests
Build / test (38, incl. a new `GET /` fan-out test) / lint / prettier pass locally.
